### PR TITLE
CT and meck

### DIFF
--- a/src/rebar_coveralls.erl
+++ b/src/rebar_coveralls.erl
@@ -44,6 +44,7 @@
 %% API functions
 
 ct(Conf, _) ->
+  true = code:add_path(rebar_utils:ebin_dir()),
   coveralls(Conf).
 
 eunit(Conf, _) ->


### PR DESCRIPTION
1) fix problem with ct when ebin not loaded
2) meck generates backup modules so we don't need push them to coveralls.io
3) fix source pathes for correct presentation on coveralls.io