### PR TITLE
allow use of repo token

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ Example `rebar.config`:
 
 And you send the coverdata to coveralls by issuing: `rebar3 coveralls send`
 
+## Example: rebar3 and CircleCI
+Example `rebar.config.script`:                                                                                      
+
+```erlang
+case {os:getenv("CIRCLECI"), os:getenv("COVERALLS_REPO_TOKEN")} of
+    {"true", Token} when is_list(Token) ->
+        JobId   = os:getenv("CIRCLE_BUILD_NUM"),
+        CONFIG1 = lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId}),
+        lists:keystore(coveralls_repo_token, 1, CONFIG1, {coveralls_repo_token, Token});
+    _ ->
+        CONFIG
+end.
+```
+
+Example `rebar.config`:
+
+```erlang
+
+{plugins                , [coveralls]}. % use hexc package
+{cover_enabled          , true}.
+{cover_export_enabled   , true}.
+{coveralls_coverdata    , "_build/test/cover/ct.coverdata"}.
+{coveralls_service_name , "circle-ci"}.
+```
+
+Note that you'll need to set `COVERALLS_REPO_TOKEN` in your CircleCI environment variables!
+
 ## Author
 Markus Ekholm (markus at botten dot org).
 

--- a/src/coveralls.erl
+++ b/src/coveralls.erl
@@ -90,8 +90,15 @@ convert_file([[_|_]|_]=Filenames, ServiceJobId, ServiceName, S) ->
                        fun(Filename) -> ok = import(S, Filename) end,
                        Filenames),
   ConvertedModules = convert_modules(S),
+
+  RepoToken =
+        case os:getenv("COVERALLS_REPO_TOKEN") of
+            false -> "";
+            Token -> "\"repo_token\": \"" ++ Token ++ "\",~n"
+        end,
+
   Str              =
-    "{~n"
+    "{~n" ++ RepoToken ++
     "\"service_job_id\": \"~s\",~n"
     "\"service_name\": \"~s\",~n"
     "\"source_files\": ~s"

--- a/src/coveralls.erl
+++ b/src/coveralls.erl
@@ -87,11 +87,16 @@ convert_and_send_file(Filenames, ServiceJobId, ServiceName, RepoToken) ->
 
 convert_file([L|_]=Filename, ServiceJobId, ServiceName, RepoToken, S) when is_integer(L) ->
   convert_file([Filename], ServiceJobId, ServiceName, RepoToken, S);
-convert_file([[_|_]|_]=Filenames, ServiceJobId, ServiceName, RepoToken, S) ->
+convert_file([[_|_]|_]=Filenames, ServiceJobId, ServiceName, RepoToken0, S) ->
   ok               = lists:foreach(
                        fun(Filename) -> ok = import(S, Filename) end,
                        Filenames),
   ConvertedModules = convert_modules(S),
+
+  RepoToken = case RepoToken0 of
+                  "" -> "";
+                  _ -> "\"repo_token\": \"" ++ RepoToken0 ++ "\",~n"
+              end,
 
   Str              =
     "{~n" ++ RepoToken ++

--- a/src/rebar3_coveralls.erl
+++ b/src/rebar3_coveralls.erl
@@ -61,7 +61,7 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
   rebar_api:info("Running coveralls...", []),
-  ConvertAndSend = fun coveralls:convert_and_send_file/3,
+  ConvertAndSend = fun coveralls:convert_and_send_file/4,
   Get            = fun(Key, Def) -> rebar_state:get(State, Key, Def) end,
   GetLocal       = fun(Key, Def) -> rebar_state:get(State, Key, Def) end,
   MaybeSkip      = fun() -> ok end,


### PR DESCRIPTION
Services other than travis have to use a repo token instead of a .coveralls.yml file in their repo.  this change formats and sends that token if it's set in the environment.