### PR TITLE
Use JSX for JSON and add additional API fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ otp_release:
 script:
   - ./rebar3 do eunit,edoc
   - ./rebar3 as test coveralls send
+notifications:
+  webhooks: https://coveralls.io/webhook

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Example `rebar.config`:
 
 Note that you'll need to set `COVERALLS_REPO_TOKEN` in your CircleCI environment variables!
 
+## Optional settings
+
+The pluging also support the `coveralls_service_pull_request` and `coveralls_parallel` settings.
+See the Coveralls documentation for the meaning of those.
+
 ## Author
 Markus Ekholm (markus at botten dot org).
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
+{deps, [{jsx, "2.10.0"}]}.
 {profiles, [{test, [{plugins, [{coveralls, {git, "https://github.com/markusn/coveralls-erl", {branch, "master"}}}]}]}]}.
 {cover_enabled          , true}.
 {cover_export_enabled   , true}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,3 +4,4 @@
 {cover_export_enabled   , true}.
 {coveralls_coverdata    , "_build/test/cover/eunit.coverdata"}. % or a string with wildcards or a list of files
 {coveralls_service_name , "travis-ci"}.
+{coveralls_parallel, true}.

--- a/src/coveralls.erl
+++ b/src/coveralls.erl
@@ -95,32 +95,29 @@ convert_file([L|_]=Filename, ServiceJobId, ServiceName, RepoToken, S) when is_in
   WildcardReader = S#s.wildcard_reader,
   Filenames = WildcardReader(Filename),
   convert_file(Filenames, ServiceJobId, ServiceName, RepoToken, S);
-convert_file([[_|_]|_]=Filenames, ServiceJobId, ServiceName, RepoToken0, S) ->
+convert_file([[_|_]|_]=Filenames, ServiceJobId, ServiceName, RepoToken, S) ->
   ok               = lists:foreach(
                        fun(Filename) -> ok = import(S, Filename) end,
                        Filenames),
   ConvertedModules = convert_modules(S),
 
-  RepoToken = case RepoToken0 of
-                  "" -> "";
-                  _ -> "\"repo_token\": \"" ++ RepoToken0 ++ "\",~n"
-              end,
-
-  Str              =
-    "{~n" ++ RepoToken ++
-    "\"service_job_id\": \"~s\",~n"
-    "\"service_name\": \"~s\",~n"
-    "\"source_files\": ~s"
-    "}",
-  lists:flatten(
-    io_lib:format(Str, [ServiceJobId, ServiceName, ConvertedModules])).
+  Report0 =
+    #{service_job_id => ServiceJobId,
+      service_name   => ServiceName,
+      source_files   => ConvertedModules},
+  Report =
+    case RepoToken of
+      <<"">> -> Report0;
+      _      -> Report0#{repo_token => RepoToken}
+    end,
+  jsx:encode(Report, []).
 
 convert_and_send_file(Filenames, ServiceJobId, ServiceName, RepoToken, S) ->
   send(convert_file(Filenames, ServiceJobId, ServiceName, RepoToken, S), S).
 
 send(Json, #s{poster=Poster, poster_init=Init}) ->
   ok       = Init(),
-  Boundary = "----------" ++ integer_to_list(?random:uniform(1000)),
+  Boundary = ["----------", integer_to_list(?random:uniform(1000))],
   Type     = "multipart/form-data; boundary=" ++ Boundary,
   Body     = to_body(Json, Boundary),
   R        = Poster(post, {?COVERALLS_URL, [], Type, Body}, [], []),
@@ -134,11 +131,11 @@ send(Json, #s{poster=Poster, poster_init=Init}) ->
 %% HTTP helpers
 
 to_body(Json, Boundary) ->
-  "--" ++ Boundary ++ "\r\n" ++
-    "Content-Disposition: form-data; name=\"json_file\"; "
-    "filename=\"json_file.json\" \r\n"
-    "Content-Type: application/json\r\n\r\n"
-    ++ Json ++ "\r\n" ++ "--" ++ Boundary ++ "--" ++ "\r\n".
+  iolist_to_binary(["--", Boundary, "\r\n",
+                    "Content-Disposition: form-data; name=\"json_file\"; "
+                    "filename=\"json_file.json\" \r\n"
+                    "Content-Type: application/json\r\n\r\n",
+                    Json, "\r\n", "--", Boundary, "--", "\r\n"]).
 
 %%-----------------------------------------------------------------------------
 %% Callback mockery
@@ -176,12 +173,20 @@ wrap_start(StartFun) ->
     ok                          -> ok
   end.
 
+digit(I) when I < 10 -> <<($0 + I):8>>;
+digit(I) -> <<($a -10 + I):8>>.
+
+hex(<<>>) ->
+  <<>>;
+hex(<<I:4, R/bitstring>>) ->
+  <<(digit(I))/binary, (hex(R))/binary>>.
+
 %%-----------------------------------------------------------------------------
 %% Converting modules
 
 convert_modules(S) ->
   F = fun(Mod) -> convert_module(Mod, S) end,
-  "[\n" ++ join(lists:map(F, imported_modules(S)), ",\n") ++ "\n]\n".
+  lists:map(F, imported_modules(S)).
 
 convert_module(Mod, S) ->
   {ok, CoveredLines0} = analyze(S, Mod),
@@ -193,17 +198,12 @@ convert_module(Mod, S) ->
     SrcFile ->
           {ok, SrcBin} = read_file(S, SrcFile),
           Src0         = lists:flatten(io_lib:format("~s", [SrcBin])),
-          SrcDigest    = binary:decode_unsigned(erlang:md5(SrcBin)),
+          SrcDigest    = erlang:md5(SrcBin),
           LinesCount   = count_lines(Src0),
           Cov          = create_cov(CoveredLines, LinesCount),
-          Str          =
-            "{~n"
-            "\"name\": \"~s\",~n"
-            "\"source_digest\": \"~.16b\",~n"
-            "\"coverage\": ~p~n"
-            "}",
-          lists:flatten(
-            io_lib:format(Str, [relative_to_cwd(SrcFile), SrcDigest, Cov]))
+      #{name          => unicode:characters_to_binary(relative_to_cwd(SrcFile), utf8, utf8),
+        source_digest => hex(SrcDigest),
+        coverage      => Cov}
   end.
 
 expand(Path) -> expand(filename:split(Path), []).
@@ -260,78 +260,75 @@ count_lines("\n")    -> 1;
 count_lines([$\n|S]) -> 1 + count_lines(S);
 count_lines([_|S])   -> count_lines(S).
 
-join(List, Sep) -> join1([E || E <- List, E /= ""], Sep).
-
-join1([H], _Sep)  -> H;
-join1([H|T], Sep) -> H ++ Sep ++ join1(T, Sep).
-
 %%=============================================================================
 %% Tests
 
 -ifdef(TEST).
+-define(DEBUG, true).
 -include_lib("eunit/include/eunit.hrl").
+
+normalize_json_str(Str) when is_binary(Str) ->
+  jsx:encode(jsx:decode(Str, [return_maps, {labels, existing_atom}]));
+normalize_json_str(Str) when is_list(Str) ->
+  normalize_json_str(iolist_to_binary(Str)).
 
 convert_file_test() ->
   Expected =
-    "{\n"
-    "\"service_job_id\": \"1234567890\",\n"
-    "\"service_name\": \"travis-ci\",\n"
-    "\"source_files\": [\n"
-    "{\n"
-    "\"name\": \"example.rb\",\n"
-    "\"source_digest\": \"3feb892deff06e7accbe2457eec4cd8b\",\n"
-    "\"coverage\": [null,1,null]\n"
-    "},\n"
-    "{\n"
-    "\"name\": \"two.rb\",\n"
-    "\"source_digest\": \"fce46ee19702bd262b2e4907a005aff4\",\n"
-    "\"coverage\": [null,1,0,null]\n"
-    "}\n"
-    "]\n"
-    "}",
-  ?assertEqual(Expected, convert_file("example.rb",
-                                      "1234567890",
-                                      "travis-ci",
-                                      "",
-                                      mock_s())).
+      jsx:decode(
+        <<"{\"service_job_id\": \"1234567890\","
+          " \"service_name\": \"travis-ci\","
+          " \"source_files\": ["
+          "    {\"name\": \"example.rb\","
+          "     \"source_digest\": \"3feb892deff06e7accbe2457eec4cd8b\","
+          "     \"coverage\": [null,1,null]"
+          "    },"
+          "    {\"name\": \"two.rb\","
+          "     \"source_digest\": \"fce46ee19702bd262b2e4907a005aff4\","
+          "     \"coverage\": [null,1,0,null]"
+          "    }"
+          "  ]"
+          "}">>, [return_maps, {labels, existing_atom}]),
+  Got = jsx:decode(
+          convert_file("example.rb", <<"1234567890">>, <<"travis-ci">>, <<"">>, mock_s()),
+          [return_maps, {labels, existing_atom}]),
+  ?assertEqual(Expected, Got).
 
 convert_and_send_file_test() ->
   Expected =
-    "{\n"
-    "\"service_job_id\": \"1234567890\",\n"
-    "\"service_name\": \"travis-ci\",\n"
-    "\"source_files\": [\n"
-    "{\n"
-    "\"name\": \"example.rb\",\n"
-    "\"source_digest\": \"3feb892deff06e7accbe2457eec4cd8b\",\n"
-    "\"coverage\": [null,1,null]\n"
-    "},\n"
-    "{\n"
-    "\"name\": \"two.rb\",\n"
-    "\"source_digest\": \"fce46ee19702bd262b2e4907a005aff4\",\n"
-    "\"coverage\": [null,1,0,null]\n"
-    "}\n"
-    "]\n"
-    "}",
+    normalize_json_str(
+      "{\"service_job_id\": \"1234567890\","
+      " \"service_name\": \"travis-ci\","
+      " \"source_files\": ["
+      "    {\"name\": \"example.rb\","
+      "     \"source_digest\": \"3feb892deff06e7accbe2457eec4cd8b\","
+      "     \"coverage\": [null,1,null]"
+      "    },"
+      "    {\"name\": \"two.rb\","
+      "     \"source_digest\": \"fce46ee19702bd262b2e4907a005aff4\","
+      "     \"coverage\": [null,1,0,null]"
+      "    }"
+      "  ]"
+      "}"),
   ?assertEqual(ok, convert_and_send_file("example.rb",
-                                         "1234567890",
-                                         "travis-ci",
-                                         "",
+                                         <<"1234567890">>,
+                                         <<"travis-ci">>,
+                                         <<"">>,
                                          mock_s(Expected))).
 
 send_test_() ->
   Expected =
-    "{\n"
-    "\"service_job_id\": \"1234567890\",\n"
-    "\"service_name\": \"travis-ci\",\n"
-    "\"source_files\": [\n"
-    "{\n"
-    "\"name\": \"example.rb\",\n"
-    "\"source_digest\": \"\tdef four\\n  4\\nend\",\n"
-    "\"coverage\": [null,1,null]\n"
-    "}\n]\n}",
+    normalize_json_str(
+      "{\"service_job_id\": \"1234567890\",\n"
+      " \"service_name\": \"travis-ci\",\n"
+      " \"source_files\": [\n"
+      "    {\"name\": \"example.rb\",\n"
+      "     \"source_digest\": \"\tdef four\\n  4\\nend\",\n"
+      "     \"coverage\": [null,1,null]\n"
+      "    }"
+      "  ]"
+      "}"),
   [ ?_assertEqual(ok, send(Expected, mock_s(Expected)))
-  , ?_assertThrow({error, {_,_}}, send("foo", mock_s("bar")))
+  , ?_assertThrow({error, {_,_}}, send("foo", mock_s(<<"bar">>)))
   ].
 
 %%-----------------------------------------------------------------------------
@@ -344,13 +341,6 @@ count_lines_test_() ->
   , ?_assertEqual(2, count_lines("foo\nbar"))
   , ?_assertEqual(3, count_lines("foo\n\nbar"))
   , ?_assertEqual(2, count_lines("foo\nbar\n"))
-  ].
-
-join_test_() ->
-  [ ?_assertEqual("a,b"  , join(["a","b"], ","))
-  , ?_assertEqual("a,b,c", join(["a","b","c"], ","))
-  , ?_assertEqual("a,c"  , join(["a","","c"], ","))
-  , ?_assertEqual("a,b"  , join(["a","b",""], ","))
   ].
 
 expand_test_() ->
@@ -454,27 +444,21 @@ create_cov_test() ->
 
 convert_module_test() ->
   Expected =
-    "{\n"
-    "\"name\": \"example.rb\",\n"
-    "\"source_digest\": \"3feb892deff06e7accbe2457eec4cd8b\",\n"
-    "\"coverage\": [null,1,null]\n"
-    "}",
-  ?assertEqual(Expected, lists:flatten(convert_module('example.rb', mock_s()))).
+    #{name          => <<"example.rb">>,
+      source_digest => <<"3feb892deff06e7accbe2457eec4cd8b">>,
+      coverage      => [null,1,null]},
+  ?assertEqual(Expected, convert_module('example.rb', mock_s())).
 
 convert_modules_test() ->
   Expected =
-    "[\n"
-    "{\n"
-    "\"name\": \"example.rb\",\n"
-    "\"source_digest\": \"3feb892deff06e7accbe2457eec4cd8b\",\n"
-    "\"coverage\": [null,1,null]\n"
-    "},\n"
-    "{\n"
-    "\"name\": \"two.rb\",\n"
-    "\"source_digest\": \"fce46ee19702bd262b2e4907a005aff4\",\n"
-    "\"coverage\": [null,1,0,null]\n"
-    "}\n"
-    "]\n",
+    [#{name          => <<"example.rb">>,
+       source_digest => <<"3feb892deff06e7accbe2457eec4cd8b">>,
+       coverage      => [null,1,null]
+      },
+     #{name          => <<"two.rb">>,
+       source_digest => <<"fce46ee19702bd262b2e4907a005aff4">>,
+       coverage      => [null,1,0,null]
+      }],
   ?assertEqual(Expected,
                convert_modules(mock_s())).
 
@@ -510,7 +494,7 @@ mock_s(Json) ->
         fun() -> ok end
     , poster        =
         fun(post, {_, _, _, Body}, _, _) ->
-            case string:str(Body, Json) =/= 0 of
+            case binary:match(Body, Json) =/= nomatch of
               true  -> {ok, {{"", 200, ""}, "", ""}};
               false -> {ok, {{"", 666, ""}, "", "Not expected"}}
             end

--- a/src/rebar3_coveralls.erl
+++ b/src/rebar3_coveralls.erl
@@ -97,11 +97,18 @@ cover_paths(State) ->
 %%=============================================================================
 %% Internal functions
 
+to_binary(List) when is_list(List) ->
+  unicode:characters_to_binary(List, utf8, utf8);
+to_binary(Atom) when is_atom(Atom) ->
+  atom_to_binary(Atom, utf8);
+to_binary(Bin) when is_binary(Bin) ->
+  Bin.
+
 do_coveralls(ConvertAndSend, Get, GetLocal, MaybeSkip, Task) ->
   File         = GetLocal(coveralls_coverdata, undef),
-  ServiceName  = GetLocal(coveralls_service_name, undef),
-  ServiceJobId = GetLocal(coveralls_service_job_id, undef),
-  RepoToken    = GetLocal(coveralls_repo_token, []),
+  ServiceName  = to_binary(GetLocal(coveralls_service_name, undef)),
+  ServiceJobId = to_binary(GetLocal(coveralls_service_job_id, undef)),
+  RepoToken    = to_binary(GetLocal(coveralls_repo_token, [])),
   F            = fun(X) -> X =:= undef orelse X =:= false end,
   CoverExport  = Get(cover_export_enabled, false),
   case lists:any(F, [File, ServiceName, ServiceJobId, CoverExport]) of
@@ -137,7 +144,7 @@ task_test_() ->
   File           = "foo",
   ServiceJobId   = "123",
   ServiceName    = "bar",
-  ConvertAndSend = fun("foo", "123", "bar", "") -> ok end,
+  ConvertAndSend = fun("foo", <<"123">>, <<"bar">>, <<"">>) -> ok end,
   Get            = fun(cover_export_enabled, _) -> true end,
   GetLocal       = fun(coveralls_coverdata, _)      -> File;
                       (coveralls_service_name, _)   -> ServiceName;


### PR DESCRIPTION
This is inspired by #25 and somewhat similar.

* it first replaces the hand crafted JSON with encoding by jsx
* it then make the coverall API more flexible by using a map for the API arguments
* and finally it adds the service_pull_request and parallel arguments

I tried to follow your coding style, but I could not get myself to mirror all of it.