### PR TITLE
Add some more envs for GitHub Action services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 _build
 rebar.lock
 .rebar
+.rebar3

--- a/README.md
+++ b/README.md
@@ -74,9 +74,17 @@ In order to use coveralls-erl + GitHub Actions in your project, you will need to
 ```erlang
 case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
   {"true", Token} when is_list(Token) ->
-    JobId = os:getenv("GITHUB_RUN_ID"),
-    CONFIG1 = lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId}),
-    lists:keystore(coveralls_repo_token, 1, CONFIG1, {coveralls_repo_token, Token});
+    CONFIG1 = [{coveralls_repo_token, Token},
+               {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
+               {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
+               {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")} | CONFIG],
+    case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
+        andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
+        [_, "pull", PRNO, _] ->
+            [{coveralls_service_pull_request, PRNO} | CONFIG1];
+        _ ->
+            CONFIG1
+    end;
   _ ->
     CONFIG
 end.

--- a/src/rebar3_coveralls.erl
+++ b/src/rebar3_coveralls.erl
@@ -127,6 +127,8 @@ do_coveralls(ConvertAndSend, Get, GetLocal, MaybeSkip, Task) ->
       service_name   => ServiceName},
   Opts = [{coveralls_repo_token,           repo_token,           string},
           {coveralls_service_pull_request, service_pull_request, string},
+          {coveralls_commit_sha,           commit_sha,           string},
+          {coveralls_service_number,       service_number,       string},
           {coveralls_parallel,             parallel,             boolean}],
   Report =
     lists:foldl(fun({Cfg, Key, Conv}, R) ->


### PR DESCRIPTION
**Motivation:**

- Coveralls can't comment on the cover rate result in the based PR. 

So I update the `rebar.config.script` to sett PR No to `coveralls-erl` plugin. And add two extra envs to enhance the friendliness of the Coveralls display.

